### PR TITLE
Haryana fixes

### DIFF
--- a/srcs/haryana.py
+++ b/srcs/haryana.py
@@ -238,7 +238,7 @@ class Haryana(AndhraArchive):
 class HaryanaArchive(Haryana):
     def __init__(self, name, storage):
         Haryana.__init__(self, name, storage)
-        self.baseurl      = 'http://www.egazetteharyana.gov.in/ArchiveNotifications.aspx'
+        self.baseurl      = 'https://www.egazetteharyana.gov.in/ArchiveNotifications.aspx'
         self.hostname     = 'www.egazetteharyana.gov.in'
         self.search_endp  = 'ArchiveNotifications.aspx'
         self.gazette_js   = 'window.open\(\'(?P<href>ArchiveNotifications[^\']+)'

--- a/srcs/haryana.py
+++ b/srcs/haryana.py
@@ -210,19 +210,6 @@ class Haryana(AndhraArchive):
                 elif t[0] == 'ctl00$ContentPlaceHolder1$ctl03':
                     t = (t[0], '10')
                 newpost.append(t)
-        
-            response = self.download_url(search_url, postdata = newpost, \
-                                         loadcookies= cookiejar)
-            if not response or not response.webpage:
-                self.logger.warning('Could not get the page for %s' % metainfo)
-                continue
-            webpage = response.webpage.decode('utf-8', 'ignore') 
-            reobj = re.search(self.gazette_js, webpage)
-            if not reobj:
-                self.logger.warning('Could not get url link for %s' % metainfo)
-                continue
-            href  = reobj.groupdict()['href']
-            gzurl = urllib.parse.urljoin(search_url, href)
 
             num = metainfo['notification_num']
             if 'gztype' in metainfo:
@@ -230,7 +217,9 @@ class Haryana(AndhraArchive):
             num, n = re.subn('[\s/().\[\]]+', '-', num)
             relurl = os.path.join(relpath, num)
 
-            if self.save_gazette(relurl, gzurl, metainfo):
+            if self.save_gazette(relurl, search_url, metainfo, \
+                                 postdata = newpost, referer = search_url, \
+                                 cookiefile = cookiejar):
                 dls.append(relurl)
 
         return dls


### PR DESCRIPTION
Not sure what was there before but POST to the download link now directly returns the PDF file. This would also mean that there is no separate url for each gazette, all of them get a common url which points to the search page. 