### PR TITLE
Move Odisha scraper to use new site

### DIFF
--- a/srcs/odisha.py
+++ b/srcs/odisha.py
@@ -1,7 +1,7 @@
 import re
 import os
 import urllib.request, urllib.parse, urllib.error
-import datetime
+from datetime import datetime
 
 from ..utils import utils
 from .basegazette import BaseGazette
@@ -9,106 +9,115 @@ from .basegazette import BaseGazette
 class Odisha(BaseGazette):
     def __init__(self, name, storage):
         BaseGazette.__init__(self, name, storage)
-        self.baseurl = 'http://govtpress.odisha.gov.in/notdtsearch.asp'
-        self.hostname = 'govtpress.odisha.gov.in'
+        self.ordinary_url = 'https://ogpress.nic.in/odishagazettes.php'
+        self.extraordinary_url = 'https://ogpress.nic.in/ex_odishagazettes.php'
+        self.hostname = 'ogpress.nic.in'
 
-    def get_post_data(self, dateobj):
-        return [('bsubmit', 'Submit'), ('select', utils.pad_zero(dateobj.day)),\
-                ('select2', utils.pad_zero(dateobj.month)), \
-                ('select3', utils.pad_zero(dateobj.year % 2000))]
-
-    def find_field_order(self, tr):
-        order  = []
-        for td in tr.find_all('td'):
+    def find_field_order(self, tr, header_type):
+        order = []
+        for td in tr.find_all(header_type):
             txt = utils.get_tag_contents(td)
-            if txt and re.search('Department', txt):
-                order.append('department')
-            elif txt and re.search('Notification\s+Number', txt):
-                order.append('notification_num')
-            elif txt and re.search('Gazette\s+Number', txt):
+            if txt and re.search('Gazette\s+Number', txt):
                 order.append('gznum')
-            elif txt and re.search('Subject', txt):
-                order.append('subject')
-            elif txt and re.search('File', txt):
-                order.append('download')
+            elif txt and re.search('Department', txt):
+                order.append('department')
             elif txt and re.search('Gazette\s+Date', txt):
                 order.append('gzdate')
+            elif txt and re.search('Action', txt):
+                order.append('download')
+            elif txt and re.search('File', txt):
+                order.append('file')
             else:
-                order.append('')    
-        
-        for field in ['department', 'download', 'subject', 'gznum', 'notification_num']:
+                order.append('')
+
+        for field in ['download', 'gznum', 'gzdate']:
             if field not in order:
                 return None
         return order
-                
-    def process_row(self, tr, order, dateobj):
+
+    def process_result_row(self, tr, dateobj, gztype, datefmt, order):
         metainfo = utils.MetaInfo()
+        metainfo.set_gztype(gztype)
         metainfo.set_date(dateobj)
+        gzdate = None
+        filename = None
         i = 0
         for td in tr.find_all('td'):
             if len(order) > i:
+                col = order[i]
                 txt = utils.get_tag_contents(td)
-                txt = txt.strip()
-                if order[i] in ['gznum', 'department', 'notification_num', 'subject']:
-                    metainfo[order[i]] = txt
-                elif order[i] == 'gzdate':
-                    nums = re.findall('\d+', txt)
-                    if len(nums) == 3:
-                        try:
-                            d = datetime.date(int(nums[2]), int(nums[1]), int(nums[0]))
-                            metainfo['gzdate'] = d
-                        except:
-                            self.logger.warning('Unable to form date for %s', txt)        
-                elif order[i] == 'download':
+                if txt:
+                    txt = txt.strip()
+                if col in ['gznum', 'department']:
+                    metainfo[col] = txt
+                elif col == 'gzdate':
+                    gzdate = txt
+                elif col == 'file':
+                    filename = txt
+                elif col == 'download':
                     link = td.find('a')
                     if link and link.get('href'):
                         metainfo['href'] =  link.get('href')    
-
             i += 1
-        if 'href' in metainfo and 'gznum' in metainfo:
-            return metainfo
-        return None
-                
-    def download_oneday(self, relpath, dateobj):
+
+        if gztype == 'Weekly':
+            if filename == None or not filename.endswith('.pdf'):
+                return None
+
+        try:
+            gzdateobj = datetime.strptime(gzdate, datefmt).date()
+        except ValueError:
+            #self.logger.warning('encountered unparsable date %s', gzdate)
+            return None
+        if gzdateobj != dateobj:
+            return None
+        return metainfo
+
+    def download_onetype(self, relpath, dateobj, srcurl, gztype, datefmt, header_type):
         dls = []
-        postdata = self.get_post_data(dateobj)
-        response = self.download_url(self.baseurl, postdata = postdata) 
+
+        response = self.download_url(srcurl)
         if not response or not response.webpage:
-            self.logger.warning('Unable to get result page for date %s', dateobj)
+            self.logger.warning('Unable to get result page for type %s for date %s', gztype, dateobj)
             return dls
 
         d = utils.parse_webpage(response.webpage, self.parser)
         if not d:     
-            self.logger.warning('Unable to parse result page for date %s', dateobj)
+            self.logger.warning('Unable to parse result page for type %s date %s', gztype, dateobj)
             return dls
 
         result_table = None
             
         for table in d.find_all('table'):
             for tr in table.find_all('tr'):
-                order = self.find_field_order(tr)
+                order = self.find_field_order(tr, header_type)
                 if order:
                     result_table = table
                     break
                  
         if result_table == None:
-            self.logger.warning('Unable to find the result table for %s', dateobj)
+            self.logger.warning('Unable to find the result table for type %s date %s', gztype, dateobj)
             return dls
 
         minfos = []
         for tr in result_table.find_all('tr'):
             if tr.find('a') == None:
                 continue
-            metainfo = self.process_row(tr, order, dateobj)
+            metainfo = self.process_result_row(tr, dateobj, gztype, datefmt, order)
             if metainfo:
                 minfos.append(metainfo)
-        
-                    
+
         for metainfo in minfos:
             href   = metainfo.pop('href')
-            url    = urllib.parse.urljoin(self.baseurl, href)
+            url    = urllib.parse.urljoin(srcurl, href)
             relurl = os.path.join(relpath, metainfo['gznum'])
-            if self.save_gazette(relurl, url, metainfo):
+            if self.save_gazette(relurl, url, metainfo, validurl = False):
                 dls.append(relurl)
 
-        return dls        
+        return dls
+
+
+    def download_oneday(self, relpath, dateobj):
+        odls = self.download_onetype(relpath, dateobj, self.ordinary_url, 'Weekly', '%Y-%m-%d', 'td')
+        edls = self.download_onetype(relpath, dateobj, self.extraordinary_url, 'ExtraOrdinary', '%d-%m-%Y', 'th')
+        return odls + edls

--- a/srcs/odisha.py
+++ b/srcs/odisha.py
@@ -1,12 +1,157 @@
 import re
 import os
 import urllib.request, urllib.parse, urllib.error
-from datetime import datetime
+from http.cookiejar import CookieJar
+from datetime import datetime, date
 
 from ..utils import utils
 from .basegazette import BaseGazette
 
+
 class Odisha(BaseGazette):
+    def __init__(self, name, storage):
+        BaseGazette.__init__(self, name, storage)
+        self.ordinary_url = 'https://govtpress.odisha.gov.in/odisha-gazettes'
+        self.extraordinary_url = 'https://govtpress.odisha.gov.in/ex-ordinary-gazettes'
+        self.hostname = 'govtpress.odisha.gov.in'
+
+    def get_post_data(self, webpage, dateobj, srcurl):
+        d = utils.parse_webpage(webpage, self.parser)
+        if d == None:
+            self.logger.warning('Unable to parse page for %s', dateobj)        
+            return None
+        search_form = d.find('form', { 'action': srcurl })
+        if search_form == None:
+            self.logger.warning('Unable to find form for %s', dateobj)        
+            return None
+        reobj  = re.compile('^(input|select|button)$')
+        inputs = search_form.find_all(reobj)
+        datestr  = datetime.strftime(dateobj, '%Y-%m-%d')
+        postdata = []
+
+        for tag in inputs:
+            name  = tag.get('name')
+            value = tag.get('value')
+            if name == 'gazette_date':
+                value = datestr
+            if name:
+                if value == None:
+                    value = ''
+                postdata.append((name, value))
+        return postdata
+
+    def find_field_order(self, tr):
+        order  = []
+        for td in tr.find_all('td'):
+            txt = utils.get_tag_contents(td)
+            if txt and re.search('Department', txt):
+                order.append('department')
+            elif txt and re.search('Notification\s+No', txt):
+                order.append('notification_num')
+            elif txt and re.search('Gazette\s+No', txt):
+                order.append('gznum')
+            elif txt and re.search('Download', txt):
+                order.append('download')
+            elif txt and re.search('Gazette\s+Date', txt):
+                order.append('gzdate')
+            elif txt and re.search('Week\s+No', txt):
+                order.append('week_num')
+            elif txt and re.search('Remarks', txt):
+                order.append('remarks')
+            else:
+                order.append('')
+        
+        for field in ['download', 'gzdate', 'gznum']:
+            if field not in order:
+                return None
+        return order
+                
+    def process_row(self, tr, order, dateobj, gztype):
+        metainfo = utils.MetaInfo()
+        metainfo.set_gztype(gztype)
+        metainfo.set_date(dateobj)
+        i = 0
+        for td in tr.find_all('td'):
+            if len(order) > i:
+                txt = utils.get_tag_contents(td)
+                txt = txt.strip()
+                if order[i] in ['gznum', 'department', 'notification_num', 'week_num', 'remarks']:
+                    metainfo[order[i]] = txt
+                elif order[i] == 'gzdate':
+                    nums = re.findall('\d+', txt)
+                    if len(nums) == 3:
+                        try:
+                            d = date(int(nums[0]), int(nums[1]), int(nums[2]))
+                            metainfo['gzdate'] = d
+                        except:
+                            self.logger.warning('Unable to form date for %s', txt)
+                elif order[i] == 'download':
+                    link = td.find('a')
+                    if link and link.get('href'):
+                        metainfo['href'] =  link.get('href')
+
+            i += 1
+        if 'href' in metainfo and 'gznum' in metainfo:
+            return metainfo
+        return None
+                
+    def download_onetype(self, relpath, dateobj, srcurl, gztype):
+        dls = []
+        cookiejar = CookieJar()
+        response = self.download_url(srcurl, savecookies = cookiejar)
+        if response == None or response.webpage == None:
+            self.logger('Unable to get the base page for %s date %s', gztype, dateobj)
+            return dls
+        postdata = self.get_post_data(response.webpage, dateobj, srcurl)
+        response = self.download_url(srcurl, postdata = postdata, \
+                                     loadcookies = cookiejar, savecookies = cookiejar) 
+        if not response or not response.webpage:
+            self.logger.warning('Unable to get result page for %s date %s', gztype, dateobj)
+            return dls
+
+        d = utils.parse_webpage(response.webpage, self.parser)
+        if not d:
+            self.logger.warning('Unable to parse result page for %s date %s', gztype, dateobj)
+            return dls
+
+        result_table = None
+            
+        for table in d.find_all('table'):
+            for tr in table.find_all('tr'):
+                order = self.find_field_order(tr)
+                if order:
+                    result_table = table
+                    break
+                 
+        if result_table == None:
+            self.logger.warning('Unable to find the result table for %s date %s', gztype, dateobj)
+            return dls
+
+        minfos = []
+        for tr in result_table.find_all('tr'):
+            if tr.find('a') == None:
+                continue
+            metainfo = self.process_row(tr, order, dateobj, gztype)
+            if metainfo:
+                minfos.append(metainfo)
+        
+                    
+        for metainfo in minfos:
+            href   = metainfo.pop('href')
+            url    = urllib.parse.urljoin(srcurl, href)
+            relurl = os.path.join(relpath, metainfo['gznum'])
+            if self.save_gazette(relurl, url, metainfo):
+                dls.append(relurl)
+
+        return dls        
+
+    def download_oneday(self, relpath, dateobj):
+        odls = self.download_onetype(relpath, dateobj, self.ordinary_url, 'Ordinary')
+        edls = self.download_onetype(relpath, dateobj, self.extraordinary_url, 'Extraordinary')
+        return odls + edls
+
+
+class Odisha1(BaseGazette):
     def __init__(self, name, storage):
         BaseGazette.__init__(self, name, storage)
         self.ordinary_url = 'https://ogpress.nic.in/odishagazettes.php'
@@ -118,6 +263,9 @@ class Odisha(BaseGazette):
 
 
     def download_oneday(self, relpath, dateobj):
-        odls = self.download_onetype(relpath, dateobj, self.ordinary_url, 'Weekly', '%Y-%m-%d', 'td')
-        edls = self.download_onetype(relpath, dateobj, self.extraordinary_url, 'ExtraOrdinary', '%d-%m-%Y', 'th')
+        odls = self.download_onetype(relpath, dateobj, self.ordinary_url, 'Ordinary', '%Y-%m-%d', 'td')
+        edls = self.download_onetype(relpath, dateobj, self.extraordinary_url, 'Extraordinary', '%d-%m-%Y', 'th')
         return odls + edls
+
+
+


### PR DESCRIPTION
Old site is no longer accesible. The newer site at https://egazette.odisha.gov.in/ doesn't have much data yet. 

The current site picked(https://ogpress.nic.in/) does seem to have data for extraordinary gazettes at-least till June 2024.

I think the equivalent of weekly gazettes for Odisha now is https://ctz.edodisha.gov.in/ . It seems to contain all government correspondence though. 

Haven't checked the stability of identifiers. Would wait before merging this. 
