### PR TITLE
Add support for handling pdf files IA has problems with

### DIFF
--- a/requirements.sync.in
+++ b/requirements.sync.in
@@ -1,4 +1,4 @@
-PyPDF2
+pymupdf
 Pillow
 lxml
 beautifulsoup4

--- a/requirements.tools.in
+++ b/requirements.tools.in
@@ -1,4 +1,4 @@
-PyPDF2
+pymupdf
 beautifulsoup4
 python-magic
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ proto-plus==1.26.1
 protobuf==5.29.4
 pyasn1==0.6.1
 pyasn1-modules==0.4.1
-pypdf2==3.0.1
+pymupdf==1.25.5
 python-magic==0.4.27
 requests==2.32.3
 requests-toolbelt==1.0.0

--- a/utils/pdf_ops.py
+++ b/utils/pdf_ops.py
@@ -1,0 +1,53 @@
+import pymupdf
+
+def extract_links_from_pdf(fileobj):
+    all_links = []
+
+    doc = pymupdf.open(fileobj)
+    for page in doc:
+        links = [ link.get('file', None) for link in page.get_links() ]
+        all_links.extend([ link for link in links if link is not None ])
+
+    return all_links
+
+def convert_to_image_pdf(file_bytes):
+    outdoc = pymupdf.open()
+
+    doc = pymupdf.open(stream=file_bytes, filetype='pdf')
+    
+    for page in doc:
+
+        img_bytes = page.get_pixmap(alpha=False, dpi=300)\
+                        .tobytes(output='jpg', jpg_quality=10)
+
+        img           = pymupdf.open(stream=img_bytes, filetype='jpg')
+        img_pdf_bytes = img.convert_to_pdf()
+        img_rect      = img[0].rect
+
+        img.close()
+
+        img_pdf = pymupdf.open(stream=img_pdf_bytes, filetype='pdf')
+
+        page = outdoc.new_page(width  = img_rect.width,
+                               height = img_rect.height)
+
+        page.show_pdf_page(img_rect, img_pdf, 0)
+
+    return outdoc.tobytes()
+
+def convert_to_image_pdf_file(inp_file, outp_file):
+    with open(inp_file, 'rb') as f:
+        file_bytes = f.read()
+
+    pdf_bytes = convert_to_image_pdf(file_bytes)
+
+    with open(outp_file, 'wb') as f:
+        f.write(pdf_bytes)
+
+
+if __name__ == '__main__':
+    import sys
+    from pathlib import Path
+    pdf_bytes = convert_to_image_pdf(Path(sys.argv[1]).read_bytes())
+    Path(sys.argv[2]).write_bytes(pdf_bytes)
+

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -9,11 +9,9 @@ import sys
 import calendar
 import logging
 
-from PyPDF2 import PdfFileReader
 from xml.parsers.expat import ExpatError
 from xml.dom import minidom, Node
 from bs4 import BeautifulSoup, NavigableString, Tag
-from functools import reduce
 
 def parse_xml(xmlpage):
     try: 
@@ -377,7 +375,6 @@ def stats_to_message(stats):
  
     return '\n'.join(messagelist)
 
-
 def get_file_type(filepath):
     mtype = magic.from_file(filepath, mime = True)
 
@@ -402,25 +399,6 @@ def get_file_extension(mtype):
         return 'png'
     return 'unkwn'
 
-def extract_links_from_pdf(fileobj):
-    doc = PdfFileReader(fileobj)
-    annots = [page.get('/Annots') for page in doc.pages]
-
-    annots = [note.getObject() for note in annots if note is not None]
-
-    annots = reduce(lambda x, y: x + y, annots)
-
-    links = []
-    for note in annots:
-        link = note.getObject().get('/A')
-        if link:
-            launch = link.getObject().get('/F')
-            if launch:
-                href = launch.getObject().get('/F')
-                if href:
-                    links.append(href)
-    return links
-
 def setup_logging(loglevel, logfile):
     leveldict = {'critical': logging.CRITICAL, 'error': logging.ERROR, \
                  'warning': logging.WARNING,   'info': logging.INFO, \
@@ -444,7 +422,4 @@ def setup_logging(loglevel, logfile):
 
 
 
-
-if __name__ == '__main__':
-    print(extract_links_from_pdf(open(sys.argv[1], 'rb')))
 


### PR DESCRIPTION
Also fixes uploading of metadata file during uploading of bad pdf. 

`pymupdf` doesn't have any external dependencies on external software like `ghostscript`/`poppler` to render pdfs, which drove the choice.

Moves some of the other pdf handling code to `pymupdf` as well.