### PR TITLE
rename keralacompose to kerala to invoke the crawler and use rawstrings

### DIFF
--- a/srcs/datasrcs.py
+++ b/srcs/datasrcs.py
@@ -79,8 +79,8 @@ srcdict = { \
 'himachal'                  : himachal.Himachal, \
 'haryana'                   : haryana.Haryana, \
 'haryanaarchive'            : haryana.HaryanaArchive, \
-'kerala'                    : kerala.Kerala, \
-'keralacompose'             : kerala.KeralaCompose, \
+#'kerala'                    : kerala.Kerala, \
+'kerala'                    : kerala.KeralaCompose, \
 'stgeorge'                  : stgeorge.StGeorge, \
 'keralalibrary'             : stgeorge.KeralaLibrary, \
 'goa'                       : goa.Goa, \

--- a/srcs/kerala.py
+++ b/srcs/kerala.py
@@ -309,172 +309,174 @@ class KeralaCompose(BaseGazette):
         odls = self.download_onetype(relpath, dateobj, 'Ordinary')
         return edls + odls
 
-class Kerala(BaseGazette):
-    def __init__(self, name, storage):
-        BaseGazette.__init__(self, name, storage)
-        self.hostname = 'www.egazette.kerala.gov.in'
-        self.latest_url = 'http://www.egazette.kerala.gov.in/'
-        self.baseurl    = self.latest_url
-        self.parser     = 'html.parser'
-
-        self.year_href =  '/%d.php'
-
-    def sync(self, fromdate, todate, event):
-        newdownloads = []
-        while fromdate <= todate:
-            if event.is_set():
-                self.logger.warning('Exiting prematurely as timer event is set')
-                break
-
-            dateobj   = fromdate.date()
-            lastdate  = datetime.datetime(fromdate.year, 12, 31)
-            if todate < lastdate:
-                lastdate = todate
-            lastdate = lastdate.date()
-
-            self.logger.info('Dates:  %s to %s', dateobj, lastdate)
-
-            dls = self.download_dates(self.name, dateobj, lastdate)
-
-            self.logger.info('Got %d gazettes between  %s and %s' % (len(dls), dateobj, lastdate))
-            newdownloads.extend(dls)
-            fromdate = datetime.datetime(fromdate.year + 1, 1, 1)
-
-        return newdownloads
-
-    def download_dates(self, relpath, fromdate, todate):
-        year = fromdate.year
-        assert year == todate.year
-        
-        dls = []
-
-        if year < 2007:
-            self.logger.warning('Sorry no data for the year %s', year)
-            return dls
-
-        href = self.year_href % year
-                
-        urls = [urllib.parse.urljoin(self.baseurl, href)]
-        if year == datetime.date.today().year:
-            urls.append(self.latest_url)
-
-        for url in urls:
-            response = self.download_url(url)
-            if not response or not response.webpage:
-                self.logger.warning('Unable to download %s. Skipping %s to %s', url, fromdate, todate)
-                continue
-            d = utils.parse_webpage(response.webpage, self.parser)
-            if not d:
-                self.logger.warning('Unable to parse %s. Skipping %s to %s', url, fromdate, todate)
-                continue
-
-            minfos = self.process_listing_page(url, d, fromdate, todate)
-            for metainfo in minfos:     
-                relurl = self.get_relurl(metainfo)
-                dateobj = metainfo.get_date()
-                if not relurl or not dateobj:
-                    self.logger.warning('Skipping. Could not get relurl/date for %s', metainfo)
-                    continue
-
-                relurl = os.path.join(relpath, dateobj.__str__(), relurl)
-                gurl   = metainfo['url']
-
-                if self.save_gazette(relurl, gurl, metainfo):
-                    dls.append(relurl)
-        return dls
-
-    def get_relurl(self, metainfo):
-        gurl  = metainfo['url']
-        words = gurl.split('/')
-        if len(words) == 0:
-            return None
-
-        filename = '.'.join(words[-1].split('.')[:-1])
-        wordlist = [filename]
-
-        pathwords = words[:-1]
-        pathwords.reverse()
-
-        i = 0
-        for word in pathwords: 
-            wordlist.append(word)
-            if word.startswith('part') or i >= 3:
-                break
-            i += 1
-        wordlist.reverse()
-            
-        relurl = '_'.join(wordlist)
-        relurl, n = re.subn('[.\s-]+', '-', relurl)
-        return relurl
-
-    def process_listing_page(self, baseurl, d, fromdate, todate):
-        minfos = []
-        for link in d.find_all('a'):
-            txt = utils.get_tag_contents(link)
-            if not txt:
-                continue
-
-            dateobj = utils.get_date_from_title(txt)
-            if not dateobj:
-                self.logger.warning('Unable to extract date from %s', txt)
-                continue
-
-            if dateobj < fromdate or dateobj > todate:
-                continue
-
-            href = link.get('href')
-            if not href:
-                continue
-
-            url = urllib.parse.urljoin(baseurl, href)
-            minfos.extend(self.datepage_metainfos(url, dateobj))       
-        return minfos
-
-    def datepage_metainfos(self, url, dateobj):
-        minfos = []
-        response = self.download_url(url)
-
-        if not response or not response.webpage:
-            self.logger.warning('Unable to download %s. Skipping', url)
-            return minfos
-
-        d = utils.parse_webpage(response.webpage, self.parser)
-        if not d:
-            self.logger.warning('Unable to parse %s. Skipping.', url)
-            return minfos
-
-        partnum = None
-        dept    = None
-        for td in d.find_all('td'):
-            colspan = td.get('colspan')
-            links   = td.find_all('a')
-            if colspan == '2' and len(links) == 0:
-                partnum =  utils.get_tag_contents(td)
-                partnum  = utils.remove_spaces(partnum)
-                dept    = None
-            elif len(links) > 0:
-                reobj  = re.compile('^(strong|a)$')
-                for x in td.find_all(reobj):
-                    if x.name == 'strong':
-                        dept = utils.get_tag_contents(x)
-                        dept = utils.remove_spaces(dept)
-                    elif x.name == 'a'  and partnum:
-                        href  = x.get('href')
-                        if not href.startswith('../pdf'):
-                            continue
-
-                        title = utils.get_tag_contents(x)
-                        title = utils.remove_spaces(title)
-
-                        metainfo = utils.MetaInfo()
-                        minfos.append(metainfo)
-
-                        metainfo.set_title(title)
-                        metainfo.set_date(dateobj)     
-                        metainfo['partnum'] = partnum
-                        if dept:
-                            metainfo['department']    = dept
-                        gzurl = urllib.parse.urljoin(url, href)
-                        metainfo['url'] = gzurl
-
-        return minfos    
+# --------- DEPRECATED CLASS, the URL is no longer reachable --------- #
+#class Kerala(BaseGazette):
+#    def __init__(self, name, storage):
+#        BaseGazette.__init__(self, name, storage)
+#        self.hostname = 'www.egazette.kerala.gov.in'
+#        self.latest_url = 'http://www.egazette.kerala.gov.in/'
+#        self.baseurl    = self.latest_url
+#        self.parser     = 'html.parser'
+#
+#        self.year_href =  '/%d.php'
+#
+#    def sync(self, fromdate, todate, event):
+#        newdownloads = []
+#        while fromdate <= todate:
+#            if event.is_set():
+#                self.logger.warning('Exiting prematurely as timer event is set')
+#                break
+#
+#            dateobj   = fromdate.date()
+#            lastdate  = datetime.datetime(fromdate.year, 12, 31)
+#            if todate < lastdate:
+#                lastdate = todate
+#            lastdate = lastdate.date()
+#
+#            self.logger.info('Dates:  %s to %s', dateobj, lastdate)
+#
+#            dls = self.download_dates(self.name, dateobj, lastdate)
+#
+#            self.logger.info('Got %d gazettes between  %s and %s' % (len(dls), dateobj, lastdate))
+#            newdownloads.extend(dls)
+#            fromdate = datetime.datetime(fromdate.year + 1, 1, 1)
+#
+#        return newdownloads
+#
+#    def download_dates(self, relpath, fromdate, todate):
+#        year = fromdate.year
+#        assert year == todate.year
+#        
+#        dls = []
+#
+#        if year < 2007:
+#            self.logger.warning('Sorry no data for the year %s', year)
+#            return dls
+#
+#        href = self.year_href % year
+#                
+#        urls = [urllib.parse.urljoin(self.baseurl, href)]
+#        if year == datetime.date.today().year:
+#            urls.append(self.latest_url)
+#
+#        for url in urls:
+#            response = self.download_url(url)
+#            if not response or not response.webpage:
+#                self.logger.warning('Unable to download %s. Skipping %s to %s', url, fromdate, todate)
+#                continue
+#            d = utils.parse_webpage(response.webpage, self.parser)
+#            if not d:
+#                self.logger.warning('Unable to parse %s. Skipping %s to %s', url, fromdate, todate)
+#                continue
+#
+#            minfos = self.process_listing_page(url, d, fromdate, todate)
+#            for metainfo in minfos:     
+#                relurl = self.get_relurl(metainfo)
+#                dateobj = metainfo.get_date()
+#                if not relurl or not dateobj:
+#                    self.logger.warning('Skipping. Could not get relurl/date for %s', metainfo)
+#                    continue
+#
+#                relurl = os.path.join(relpath, dateobj.__str__(), relurl)
+#                gurl   = metainfo['url']
+#
+#                if self.save_gazette(relurl, gurl, metainfo):
+#                    dls.append(relurl)
+#        return dls
+#
+#    def get_relurl(self, metainfo):
+#        gurl  = metainfo['url']
+#        words = gurl.split('/')
+#        if len(words) == 0:
+#            return None
+#
+#        filename = '.'.join(words[-1].split('.')[:-1])
+#        wordlist = [filename]
+#
+#        pathwords = words[:-1]
+#        pathwords.reverse()
+#
+#        i = 0
+#        for word in pathwords: 
+#            wordlist.append(word)
+#            if word.startswith('part') or i >= 3:
+#                break
+#            i += 1
+#        wordlist.reverse()
+#            
+#        relurl = '_'.join(wordlist)
+#        relurl, n = re.subn(r'[.\s-]+', '-', relurl)
+#        return relurl
+#
+#    def process_listing_page(self, baseurl, d, fromdate, todate):
+#        minfos = []
+#        for link in d.find_all('a'):
+#            txt = utils.get_tag_contents(link)
+#            if not txt:
+#                continue
+#
+#            dateobj = utils.get_date_from_title(txt)
+#            if not dateobj:
+#                self.logger.warning('Unable to extract date from %s', txt)
+#                continue
+#
+#            if dateobj < fromdate or dateobj > todate:
+#                continue
+#
+#            href = link.get('href')
+#            if not href:
+#                continue
+#
+#            url = urllib.parse.urljoin(baseurl, href)
+#            minfos.extend(self.datepage_metainfos(url, dateobj))       
+#        return minfos
+#
+#    def datepage_metainfos(self, url, dateobj):
+#        minfos = []
+#        response = self.download_url(url)
+#
+#        if not response or not response.webpage:
+#            self.logger.warning('Unable to download %s. Skipping', url)
+#            return minfos
+#
+#        d = utils.parse_webpage(response.webpage, self.parser)
+#        if not d:
+#            self.logger.warning('Unable to parse %s. Skipping.', url)
+#            return minfos
+#
+#        partnum = None
+#        dept    = None
+#        for td in d.find_all('td'):
+#            colspan = td.get('colspan')
+#            links   = td.find_all('a')
+#            if colspan == '2' and len(links) == 0:
+#                partnum =  utils.get_tag_contents(td)
+#                partnum  = utils.remove_spaces(partnum)
+#                dept    = None
+#            elif len(links) > 0:
+#                reobj  = re.compile('^(strong|a)$')
+#                for x in td.find_all(reobj):
+#                    if x.name == 'strong':
+#                        dept = utils.get_tag_contents(x)
+#                        dept = utils.remove_spaces(dept)
+#                    elif x.name == 'a'  and partnum:
+#                        href  = x.get('href')
+#                        if not href.startswith('../pdf'):
+#                            continue
+#
+#                        title = utils.get_tag_contents(x)
+#                        title = utils.remove_spaces(title)
+#
+#                        metainfo = utils.MetaInfo()
+#                        minfos.append(metainfo)
+#
+#                        metainfo.set_title(title)
+#                        metainfo.set_date(dateobj)     
+#                        metainfo['partnum'] = partnum
+#                        if dept:
+#                            metainfo['department']    = dept
+#                        gzurl = urllib.parse.urljoin(url, href)
+#                        metainfo['url'] = gzurl
+#
+#        return minfos    
+#

--- a/sync.py
+++ b/sync.py
@@ -56,7 +56,7 @@ def print_usage(progname):
     print('todate is not specified then the default is your current date.')
 
 def to_datetime(datestr):
-    numlist = re.findall('\d+', datestr)
+    numlist = re.findall(r'\d+', datestr)
     if len(numlist) != 3:
         print('%s not in correct format [DD/MM/YYYY]' % datestr, file=sys.stderr)
         return None


### PR DESCRIPTION
- KeralaCompose class has been renamed to Kerala as old Kerala class name had outdated url
- Added raw strings for regular expresions to avaoid getting warning on new python versions
- Now, kerala can be used to invoke the crawler instead of keralacompose
- Commented out the out-dated Kerala class