### PR TITLE
fix: rajasthan dms downloads failing with legacy TLS renegotiation error

### DIFF
--- a/srcs/basegazette.py
+++ b/srcs/basegazette.py
@@ -6,6 +6,7 @@ import time
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
+import ssl
 
 from ..utils import utils
 
@@ -47,6 +48,12 @@ class Downloader:
         self.logger      = logging.getLogger('crawler.%s' % self.name)
 
         self.useragent   = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0'
+
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode    = ssl.CERT_NONE
+        ctx.options       |= 0x4  # OP_LEGACY_SERVER_CONNECT
+        self._ssl_ctx      = ctx
 
     def all_downloads(self, event):
         start_date = get_start_date(self.name)
@@ -135,13 +142,13 @@ class Downloader:
 
     def download_url(self, url, loadcookies = None, savecookies = None, \
                      postdata = None, referer = None, \
-                     encodepost= True, headers = {}, fixurl = True, method = None):
+                     encodepost= True, headers = {}, fixurl = True, method = None, legacy_ssl_context = False):
         for i in range(0, self.num_http_retries):
             if i > 0:
                 time.sleep(i * self.retry_delay_base_secs)
             response = self.download_url_onetime(url, loadcookies, savecookies,\
                                                  postdata, referer, \
-                                                 encodepost, headers, fixurl, method)
+                                                 encodepost, headers, fixurl, method, legacy_ssl_context)
             if response.error == None:
                 return response
             elif isinstance(response.error, urllib.error.HTTPError) and \
@@ -153,7 +160,7 @@ class Downloader:
         return None
 
     def download_url_onetime(self, url, loadcookies, savecookies, \
-                             postdata, referer, encodepost, headers , fixurl, method):
+                             postdata, referer, encodepost, headers , fixurl, method, legacy_ssl_context):
 
         webresponse = WebResponse()
 
@@ -188,6 +195,37 @@ class Downloader:
                 request.headers['Cookie'] = request.unredirected_hdrs.pop('Cookie')
         self.logger.debug('Request url: %s headers: %s data: %s', \
                             request.full_url, request.headers, request.data)
+        
+        # If legacy ssl context required, send custom built https_handler
+        if legacy_ssl_context:
+            try:
+                https_handler = urllib.request.HTTPSHandler(context=self._ssl_ctx)
+                opener        = urllib.request.build_opener(https_handler)
+                response_obj  = opener.open(request, timeout=self.request_timeout_secs)
+                response      = response_obj.info()
+                webpage       = response_obj.read()
+
+                webresponse.set_webpage(webpage)
+                webresponse.set_srvresponse(response)
+                webresponse.set_response_url(response_obj.geturl())
+
+                self.logger.info('Url: %s response_url: %s Status: %s', \
+                                fixed_url, response_obj.geturl(), response_obj.getcode())
+            except Exception as e:
+                webresponse.set_error(e)
+                self.logger.warning('Could not fetch: %s error: %s', url, e)
+                return webresponse
+
+            self.logger.debug('Server response: %s', response)
+
+            if 'Set-Cookie' in response:
+                cookie = response['Set-Cookie']
+                if savecookies is not None and cookie:
+                    savecookies.extract_cookies(response_obj, request)
+
+            return webresponse
+
+        # Default ssl context
         try:
             opener  = urllib.request.urlopen(request, timeout = self.request_timeout_secs)
             response = opener.info()
@@ -246,16 +284,18 @@ class BaseGazette(Downloader):
     
     def pull_gazette(self, gurl, referer = None, postdata = None,
                      cookiefile = None, headers = {}, \
-                     encodepost = True):
+                     encodepost = True, legacy_ssl_context = False):
         if cookiefile:
             response = self.download_url(gurl, referer = referer, \
                                          postdata = postdata, loadcookies = cookiefile,\
-                                         headers = headers, encodepost = encodepost)
+                                         headers = headers, encodepost = encodepost, \
+                                         legacy_ssl_context = legacy_ssl_context)
         else:
             response = self.download_url(gurl, postdata = postdata, \
                                          encodepost = encodepost, \
                                          headers = headers, \
-                                         referer = referer)
+                                         referer = referer, \
+                                         legacy_ssl_context = legacy_ssl_context)
 
         return response
 

--- a/srcs/basegazette.py
+++ b/srcs/basegazette.py
@@ -53,6 +53,7 @@ class Downloader:
         ctx.check_hostname = False
         ctx.verify_mode    = ssl.CERT_NONE
         ctx.options       |= 0x4  # OP_LEGACY_SERVER_CONNECT
+        ctx.set_ciphers('HIGH:!DH:!aNULL')
         self._ssl_ctx      = ctx
 
     def all_downloads(self, event):
@@ -239,7 +240,10 @@ class Downloader:
         if 'Set-Cookie' in response: 
             cookie = response['Set-Cookie']
             if savecookies != None and cookie:
-                savecookies.extract_cookies(opener, request)
+                if legacy_ssl_context:
+                    savecookies.extract_cookies(response_obj, request)
+                else:
+                    savecookies.extract_cookies(opener, request)
 
         return webresponse
 

--- a/srcs/basegazette.py
+++ b/srcs/basegazette.py
@@ -281,18 +281,16 @@ class BaseGazette(Downloader):
     
     def pull_gazette(self, gurl, referer = None, postdata = None,
                      cookiefile = None, headers = {}, \
-                     encodepost = True, legacy_ssl_context = False):
+                     encodepost = True):
         if cookiefile:
             response = self.download_url(gurl, referer = referer, \
                                          postdata = postdata, loadcookies = cookiefile,\
-                                         headers = headers, encodepost = encodepost, \
-                                         legacy_ssl_context = legacy_ssl_context)
+                                         headers = headers, encodepost = encodepost)
         else:
             response = self.download_url(gurl, postdata = postdata, \
                                          encodepost = encodepost, \
                                          headers = headers, \
-                                         referer = referer, \
-                                         legacy_ssl_context = legacy_ssl_context)
+                                         referer = referer)
 
         return response
 

--- a/srcs/basegazette.py
+++ b/srcs/basegazette.py
@@ -217,31 +217,24 @@ class Downloader:
                 return webresponse
 
             self.logger.debug('Server response: %s', response)
-
-            if 'Set-Cookie' in response:
-                cookie = response['Set-Cookie']
-                if savecookies is not None and cookie:
-                    savecookies.extract_cookies(response_obj, request)
-
-            return webresponse
-
+        else:
         # Default ssl context
-        try:
-            opener  = urllib.request.urlopen(request, timeout = self.request_timeout_secs)
-            response = opener.info()
-            webpage  = opener.read()
-            
-            webresponse.set_webpage(webpage)
-            webresponse.set_srvresponse(response)
-            webresponse.set_response_url(opener.geturl())
+            try:
+                opener  = urllib.request.urlopen(request, timeout = self.request_timeout_secs)
+                response = opener.info()
+                webpage  = opener.read()
+                
+                webresponse.set_webpage(webpage)
+                webresponse.set_srvresponse(response)
+                webresponse.set_response_url(opener.geturl())
 
-            self.logger.info('Url: %s response_url: %s Status: %s' % (fixed_url, opener.geturl(), opener.getcode()))
-        except Exception as e:
-            webresponse.set_error(e)
-            self.logger.warning('Could not fetch: %s error: %s' % (url, e))
-            return webresponse 
+                self.logger.info('Url: %s response_url: %s Status: %s' % (fixed_url, opener.geturl(), opener.getcode()))
+            except Exception as e:
+                webresponse.set_error(e)
+                self.logger.warning('Could not fetch: %s error: %s' % (url, e))
+                return webresponse 
 
-        self.logger.debug('Server response: %s', response)
+            self.logger.debug('Server response: %s', response)
 
         if 'Set-Cookie' in response: 
             cookie = response['Set-Cookie']

--- a/srcs/rajasthan.py
+++ b/srcs/rajasthan.py
@@ -9,20 +9,10 @@ from http.cookiejar import CookieJar
 
 import requests
 import urllib3
-import ssl
 
 from ..utils import utils
 from .basegazette import BaseGazette
 
-default_ssl_context_creator = ssl._create_default_https_context
-
-def legacy_negotiation_enabled_context_creator(*args, **kwargs):
-    ctx = default_ssl_context_creator(*args, **kwargs)
-    ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
-    return ctx
-
-ssl._create_default_https_context = legacy_negotiation_enabled_context_creator
-    
 class CustomHttpAdapter(requests.adapters.HTTPAdapter):
     # "Transport adapter" that allows us to use custom ssl_context.
 
@@ -44,7 +34,6 @@ class RajasthanBase(BaseGazette):
         self.baseurl = 'https://reams.rajasthan.gov.in'
         self.hostname = 'reams.rajasthan.gov.in'
         self.gztype  = ''
-
 
     def get_post_data(self, tags, dateobj):
         postdata = []
@@ -290,7 +279,7 @@ class RajasthanBase(BaseGazette):
 
         response = self.download_url(post_url, loadcookies = cookiejar, savecookies = cookiejar, \
                                      postdata = newpost_encoded, headers = headers, \
-                                     encodepost = False, referer = search_url)
+                                     encodepost = False, referer = search_url, legacy_ssl_context = True)
 
         return response
 
@@ -301,7 +290,7 @@ class RajasthanBase(BaseGazette):
         response = self.download_url(url, postdata = postdata_encoded, \
                                      encodepost = False, headers = headers, \
                                      loadcookies = cookiejar, savecookies = cookiejar,
-                                     referer = referer)
+                                     referer = referer, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not get response for %s', url)
             return None
@@ -541,11 +530,9 @@ class RajasthanBase(BaseGazette):
         return query_params, postdata
     
     def get_session(self):
-        ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-        ctx.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
         session = requests.session()
         retry = self.get_session_retry()
-        session.mount('https://', CustomHttpAdapter(ctx, max_retries=retry))
+        session.mount('https://', CustomHttpAdapter(self._ssl_ctx, max_retries=retry))
         return session
 
     def download_metainfo_wrapped(self, relpath, metainfo, gztype): 
@@ -645,7 +632,8 @@ class RajasthanBase(BaseGazette):
 
         return BaseGazette.pull_gazette(self, download_url, postdata = download_postdata, \
                                         cookiefile = cookiejar, referer = redirect_url_base, \
-                                        encodepost = encodepost, headers = headers)
+                                        encodepost = encodepost, headers = headers, \
+                                        legacy_ssl_context = True)
 
 
     def download_metainfo(self, relpath, metainfo, gztype): 

--- a/srcs/rajasthan.py
+++ b/srcs/rajasthan.py
@@ -632,8 +632,7 @@ class RajasthanBase(BaseGazette):
 
         return BaseGazette.pull_gazette(self, download_url, postdata = download_postdata, \
                                         cookiefile = cookiejar, referer = redirect_url_base, \
-                                        encodepost = encodepost, headers = headers, \
-                                        legacy_ssl_context = True)
+                                        encodepost = encodepost, headers = headers)
 
 
     def download_metainfo(self, relpath, metainfo, gztype): 

--- a/srcs/uttarakhand.py
+++ b/srcs/uttarakhand.py
@@ -92,7 +92,7 @@ class Uttarakhand(BaseGazette):
         dls = []
 
         cookiejar  = CookieJar()
-        response   = self.download_url(self.searchurl, savecookies = cookiejar)
+        response   = self.download_url(self.searchurl, savecookies = cookiejar, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not get base page for date %s', \
                               dateobj)
@@ -119,7 +119,7 @@ class Uttarakhand(BaseGazette):
 
             response = self.download_url(self.searchurl, savecookies = cookiejar, \
                                        loadcookies = cookiejar, postdata = formdata, \
-                                       referer = self.searchurl)
+                                       referer = self.searchurl, legacy_ssl_context = True)
             if not response or not response.webpage:
                 self.logger.warning('Could not make call to update field %s for date %s', \
                                     field_to_update, dateobj)
@@ -129,7 +129,7 @@ class Uttarakhand(BaseGazette):
         formdata.append(('Button2', 'Search'))
         response = self.download_url(self.searchurl, savecookies = cookiejar, \
                                    loadcookies = cookiejar, postdata = formdata, \
-                                   referer = self.baseurl)
+                                   referer = self.baseurl, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not download search result for date %s', \
                               dateobj)
@@ -240,78 +240,11 @@ class UttarakhandBase(BaseGazette):
         self.cookiejar   = CookieJar()
         self.lookback    = 15
 
-        # gazettes.uk.gov.in requires legacy TLS renegotiation.
-        # Build a dedicated SSL context so this doesn't affect other crawlers.
-        # Making this global would be overriden by other crawler imports in datasrcs
-        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ctx.check_hostname = False
-        ctx.verify_mode    = ssl.CERT_NONE
-        ctx.options       |= 0x4  # OP_LEGACY_SERVER_CONNECT
-        self._ssl_ctx      = ctx
 
-    def download_url_onetime(self, url, loadcookies, savecookies,
-                             postdata, referer, encodepost, headers, fixurl, method):
-        from .basegazette import WebResponse
-        webresponse = WebResponse()
-
-        if self.backoff > 0:
-            time.sleep(self.backoff)
-
-        headers['User-agent'] = self.useragent
-        if referer:
-            headers['Referer'] = referer
-
-        encodedData = None
-        if postdata:
-            if encodepost:
-                encodedData = urllib.parse.urlencode(postdata).encode('utf-8')
-            else:
-                encodedData = postdata
-
-        fixed_url = self.url_fix(url) if fixurl else url
-
-        if method is None:
-            request = urllib.request.Request(fixed_url, encodedData, headers)
-        else:
-            request = urllib.request.Request(fixed_url, encodedData, headers, method=method)
-
-        if loadcookies is not None:
-            loadcookies.add_cookie_header(request)
-            if 'Cookie' in request.unredirected_hdrs:
-                request.headers['Cookie'] = request.unredirected_hdrs.pop('Cookie')
-
-        self.logger.debug('Request url: %s headers: %s data: %s',
-                          request.full_url, request.headers, request.data)
-        try:
-            https_handler = urllib.request.HTTPSHandler(context=self._ssl_ctx)
-            opener        = urllib.request.build_opener(https_handler)
-            response_obj  = opener.open(request, timeout=self.request_timeout_secs)
-            response      = response_obj.info()
-            webpage       = response_obj.read()
-
-            webresponse.set_webpage(webpage)
-            webresponse.set_srvresponse(response)
-            webresponse.set_response_url(response_obj.geturl())
-
-            self.logger.info('Url: %s response_url: %s Status: %s',
-                             fixed_url, response_obj.geturl(), response_obj.getcode())
-        except Exception as e:
-            webresponse.set_error(e)
-            self.logger.warning('Could not fetch: %s error: %s', url, e)
-            return webresponse
-
-        self.logger.debug('Server response: %s', response)
-
-        if 'Set-Cookie' in response:
-            cookie = response['Set-Cookie']
-            if savecookies is not None and cookie:
-                savecookies.extract_cookies(response_obj, request)
-
-        return webresponse
     
     def get_cookies(self):
         url = urllib.parse.urljoin(self.baseurl, 'en/Search/index')
-        self.download_url(url, savecookies = self.cookiejar)
+        self.download_url(url, savecookies = self.cookiejar, legacy_ssl_context = True)
     
     def get_payload(self, dateobj):
         date_to_str = dateobj.strftime("%Y-%m-%d")
@@ -334,7 +267,7 @@ class UttarakhandBase(BaseGazette):
 
         response   = self.download_url(search_url, postdata = payload,\
                                        loadcookies = self.cookiejar, 
-                                       savecookies = self.cookiejar)
+                                       savecookies = self.cookiejar, legacy_ssl_context = True)
         
         if (not response) or (not response.webpage):
             return None

--- a/srcs/westbengal.py
+++ b/srcs/westbengal.py
@@ -1,6 +1,5 @@
 import os
 import urllib.parse
-import ssl
 import re
 import json
 import time
@@ -16,16 +15,6 @@ from ..utils import utils
 
 # Create custom SSL context to handle weak DH key on wbsl.gov.in
 warnings.filterwarnings('ignore', message='.*unverified.*')
-
-def create_weak_ssl_context():
-    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    # Use ciphers that exclude DH to avoid DH_KEY_TOO_SMALL error
-    ctx.set_ciphers('HIGH:!DH:!aNULL')
-    return ctx
-
-ssl._create_default_https_context = create_weak_ssl_context
 
 
 class KolkataWBSL(BaseGazette):
@@ -206,7 +195,7 @@ class KolkataWBSL(BaseGazette):
         # AJAX endpoint uses GET with query parameters
         url = self.ajax_url + '?' + urllib.parse.urlencode(params)
         
-        response = self.download_url(url, loadcookies=cookiejar, savecookies=cookiejar, referer=referer)
+        response = self.download_url(url, loadcookies=cookiejar, savecookies=cookiejar, referer=referer, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not fetch gazette list at offset %d', display_start)
             return None
@@ -247,7 +236,7 @@ class KolkataWBSL(BaseGazette):
         # AJAX endpoint uses GET with query parameters
         url = self.ajax_url + '?' + urllib.parse.urlencode(params)
         
-        response = self.download_url(url)
+        response = self.download_url(url, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not fetch gazette list at offset %d', display_start)
             return None
@@ -288,7 +277,7 @@ class KolkataWBSL(BaseGazette):
         
         url = f'{self.bookreader_url}?bookId={bookid}'
         
-        response = self.download_url(url)
+        response = self.download_url(url, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not fetch book reader page for bookid %s', bookid)
             return None
@@ -420,7 +409,7 @@ class KolkataWBSL(BaseGazette):
             
             img_url = f'{base_url}{page_str}.jpg'
             
-            response = self.download_url(img_url)
+            response = self.download_url(img_url, legacy_ssl_context = True)
             if not response or not response.webpage:
                 self.logger.warning('Could not download page %d from %s', page_num, img_url)
                 continue
@@ -548,7 +537,7 @@ class KolkataWBSL(BaseGazette):
         # Establish session by visiting main page first
         cookiejar = CookieJar()
         
-        response = self.download_url(self.baseurl, savecookies=cookiejar)
+        response = self.download_url(self.baseurl, savecookies=cookiejar, legacy_ssl_context = True)
         if not response or not response.webpage:
             self.logger.warning('Could not establish session at %s', self.baseurl)
             return dls


### PR DESCRIPTION
 -  dms.rajasthan.gov.in requires OP_LEGACY_SERVER_CONNECT, which rajasthan.py enabled via a global ssl._create_default_https_context override. 
- Since `datasrcs.py` imports westbengal after rajasthan, westbengal's own global override clobbered it, breaking all dms.rajasthan.gov.in requests.
- Move the legacy SSL context onto Downloader as self._ssl_ctx and add an opt-in legacy_ssl_context flag to download_url/download_url_onetime/pull_gazette, then use it for rajasthan's dms.rajasthan.gov.in calls instead of mutating global ssl state.