### PR TITLE
Fix Tripura crawler: remove master token, match browser headers, and implement PDF download pipeline

### DIFF
--- a/iasync.py
+++ b/iasync.py
@@ -495,6 +495,9 @@ class GazetteIA:
          ('division',         'Division'), \
          ('notification_for', 'Notification For'), \
          ('section',          'Section'), \
+         ('policy',           'Policy'), \
+         ('sector',           'Sector'), \
+         ('organization',     'Organization'), \
        ]
        for k, kdesc in keys:
            if k in metainfo:

--- a/srcs/basegazette.py
+++ b/srcs/basegazette.py
@@ -248,23 +248,22 @@ class Downloader:
         return webresponse
 
     def url_fix(self, s, charset='utf-8'):
-        """Sometimes you get an URL by a user that just isn't a real
-        URL because it contains unsafe characters like ' ' and so on.  This
+        """Sometimes you get a URL by a user that just isn't a real
+        URL because it contains unsafe characters like ' ' and so on. This
         function can fix some of the problems in a similar way browsers
-        handle data entered by the user:
+        handle data entered by the user.
 
-        >>> url_fix(u'http://de.wikipedia.org/wiki/Elf (Begriffsklrung)')
+        >>> url_fix(u'http://de.wikipedia.org/wiki/Elf (Begriffsklärung)')
         'http://de.wikipedia.org/wiki/Elf%20%28Begriffskl%C3%A4rung%29'
 
-        :param charset: The target charset for the URL if the url was
-                        given as unicode string.
+        :param s: the URL to fix
+        :param charset: the target charset for the URL if the URL was
+                        given as a unicode string
         """
         purl = urllib.parse.urlsplit(s)
         path = urllib.parse.quote(purl.path, '/%')
         qs = urllib.parse.quote_plus(purl.query, ':&=')
-
-        return urllib.parse.urlunsplit((purl.scheme, purl.netloc, path, \
-                                        qs, purl.fragment))
+        return urllib.parse.urlunsplit((purl.scheme, purl.netloc, path, qs, purl.fragment))
 
 class BaseGazette(Downloader):
     def __init__(self, name, storage_manager):

--- a/srcs/datasrcs_info.py
+++ b/srcs/datasrcs_info.py
@@ -444,14 +444,14 @@ srcinfos = {
         'source'    : 'Government of Tripura',
         'category'  : 'Tripura Ordinary Gazette',
         # 'start_date': datetime(2018, 1, 1), for the previous verison of the source
-        'start_date': datetime(2025, 8, 30)
+        'start_date': datetime(2025, 12, 4)
     },
     'tripura_extraordinary' : {
         'languages' : ['eng'],
         'source'    : 'Government of Tripura',
         'category'  : 'Tripura Extraordinary Gazette',
         # 'start_date': datetime(2018, 1, 1), for the previous verison of the source
-        'start_date': datetime(2025, 8, 30)
+        'start_date': datetime(2026, 1, 8)
     },
     'lakshadweep' : {
         'languages' : ['eng', 'hin'],

--- a/srcs/tripura.py
+++ b/srcs/tripura.py
@@ -12,20 +12,77 @@ import urllib.error
 from .basegazette import BaseGazette
 from ..utils import utils
 from ..utils import decode_captcha
+import time as t
 
+'''
+Tripura egazette server invalidates captcha regardless of the proper value when ever ordinary gazette type is selected
+Only Gazette type 2 (Extra-Ordinary): [ddlntype], is being returned by the server
+The server also returns multiple pdfs on a single day, ordered by from-to date
+Verified that the server is able to return only Extra-Ordinary Gazette pdfs and No ordinary gazettes regardless of the selection,
+Master Token has been disabled in the website (commented-out), the serever does not require a master token. 
+'''
 
 class TripuraBase(BaseGazette):
     def __init__(self, name, storage):
         BaseGazette.__init__(self, name, storage)
         self.baseurl      = 'https://egazette.tripura.gov.in/egazette/'
         self.hostname     = 'egazette.tripura.gov.in'
-        self.search_endp  = '/egazette/newsearchresultpage.jsp'
-        self.gztype       = ''
+        self.search_endp  = 'newsearchresultpage.jsp'
+        self.gztype       = ''                              # Can't set as the server rejects captcha
+        self.captcha_url  = 'CaptchaGen?timestamp=%s'       # Pass time
 
-    def get_captcha_value(self, cookiejar, referer):
-        captcha_url = urllib.parse.urljoin(self.baseurl, 'CaptchaGen')
+        self.pdf_table_ref = 'home.jsp'
+        self.pdf_file_hash = 'AjaxServlet'                  # Gets file hash
+        self.html_pdf_embedding = 'Reports/viewSearchDocument.jsp?aid=%s~1&hash=%s'             # Pass extracted value from the table row for the pdf, pass pdf file hash
 
-        response = self.download_url(captcha_url, loadcookies = cookiejar, referer = referer)
+        self.headers = {
+            'Accept': 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Connection': 'keep-alive',
+            'Sec-Fetch-Dest': 'image',
+            'Sec-Fetch-Mode': 'no-cors',
+            'Sec-Fetch-Site': 'same-origin',
+            'sec-ch-ua': '"Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Linux"',
+        }
+
+        self.search_headers = {
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Cache-Control': 'max-age=0',
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Origin': f'https://{self.hostname}',
+            'Sec-Fetch-Dest': 'document',
+            'Sec-Fetch-Mode': 'navigate',
+            'Sec-Fetch-Site': 'same-origin',
+            'Sec-Fetch-User': '?1',
+            'Upgrade-Insecure-Requests': '1',
+            'sec-ch-ua': '"Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Linux"',
+        }
+
+        self.hash_headers = {
+            'Accept': '*/*',
+            'Accept-Language': 'en-US,en;q=0.9',
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'Origin': f'https://{self.hostname}',
+            'X-Requested-With': 'XMLHttpRequest',
+            'Sec-Fetch-Dest': 'empty',
+            'Sec-Fetch-Mode': 'cors',
+            'Sec-Fetch-Site': 'same-origin',
+            'sec-ch-ua': '"Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Linux"',
+        }
+
+    def get_new_captcha_value(self, cookiejar, referer):
+        captcha_url = urllib.parse.urljoin(self.baseurl, self.captcha_url % int(t.time() * 1000))
+
+        response = self.download_url(captcha_url, loadcookies = cookiejar, referer = referer, headers = self.headers)
         if response is None or response.webpage is None:
             self.logger.warning('Unable to download captcha')
             return None
@@ -35,7 +92,11 @@ class TripuraBase(BaseGazette):
         captcha_val = decode_captcha.tripura(img)
 
         return captcha_val
-        
+
+    # <get_post_data> Not being called by any function, we're building the postdata with <build_search_postdata> function, without scraping them from the website
+    # When the website behaves properly and accepts gazette type without rejecting the captcha, we can use this function
+    # Or we can set the gazette type manually inside of the <build_search_postdata> function to check if the gazette type is available and download the gazettes
+    # This only works if the server response is proper, currently server responds only to ExtraOrdinary Gazette     
     def get_post_data(self, tags, fromdate, todate):
         fromstr = fromdate.strftime('%Y-%m-%d')
         tostr   = todate.strftime('%Y-%m-%d')
@@ -69,33 +130,56 @@ class TripuraBase(BaseGazette):
         return postdata
 
 
-    def get_form_data(self, webpage, cookiejar, curr_url, fromdate, todate):
-        search_form = utils.get_search_form(webpage, self.parser, self.search_endp)
-        if search_form is None:
-            self.logger.warning('Unable to locate search form for %s to %s', fromdate, todate)
-            return None
+    def solve_captcha(self, cookiejar):
+        referer = self.baseurl + self.search_endp
+        captcha_value = self.get_new_captcha_value(cookiejar, referer)
+        if captcha_value:
+            self.logger.info("Solved captcha: %s", captcha_value)
+            return captcha_value
 
-        reobj  = re.compile('^(input|select)$')
-        inputs = search_form.find_all(reobj)
-        postdata = self.get_post_data(inputs, fromdate, todate)
+        self.logger.warning("Error solving captcha, Re-trying")
+        for try_count in range(4):
+            t.sleep(1)
+            captcha_value = self.get_new_captcha_value(cookiejar, referer)
+            if captcha_value:
+                self.logger.info("Solved captcha: %s", captcha_value)
+                return captcha_value
+            self.logger.error("Error solving captcha, Re-trying %s", try_count + 1)
 
-        captcha_value = self.get_captcha_value(cookiejar, curr_url)
-        if captcha_value is None:
-            return None
+        self.logger.error("Failed to solve captcha after all retries")
+        return None
 
-        postdata.append(('txtkeyword', ''))
-        postdata.append(('txtcaptchadata', captcha_value))
-        postdata.append(('btns', ''))
+    def build_search_postdata(self, fromdate, todate, captcha_value):
+        fromstr = fromdate.strftime('%Y-%m-%d')
+        tostr   = todate.strftime('%Y-%m-%d')
 
-        return postdata
+        return [
+            ('searchtype',     'G'),
+            ('ddldepartment',  ''),
+            ('ddlntype',       self.gztype),
+            ('ddlcatory',      ''),
+            ('ddlsector',      ''),
+            ('ddlpolicy',      ''),
+            ('txtgazno',       ''),
+            ('txtnotificno',   ''),
+            ('txtkeyword',     ''),
+            ('txtdatefrom',    fromstr),
+            ('txtdateto',      tostr),
+            ('txtcaptchadata', captcha_value),
+        ]
 
     def get_results_table(self, webpage):
         d = utils.parse_webpage(webpage, self.parser)
         if d is None:
+            self.logger.error("Unable to get gazette pdfs table")
             return None
 
-        results_table = d.find('table', {'id': 'qryresults'})
-
+        results_table = d.find('table', {'id': 'searchResultTable'})
+        if results_table:
+            self.logger.info("Found gazette pdfs table")
+            return results_table
+        
+        self.logger.info("Gazette pdfs table Not Found!")
         return results_table
 
     def process_row(self, metainfos, tr, order):
@@ -121,15 +205,15 @@ class TripuraBase(BaseGazette):
                         metainfo.set_gztype('Ordinary')
 
                 elif col == 'download':
-                    link = td.find('a')
-                    if link and link.get('href'):
-                        metainfo['href'] = link.get('href')
+                    btn = td.find('button', {'name': 'viewDeptRouteDocument'})
+                    if btn and btn.get('value'):
+                        metainfo['doc_id'] = btn.get('value')
 
                 elif col != '':
                     metainfo[col] = txt
             i += 1
 
-        if 'href' in metainfo:
+        if 'doc_id' in metainfo:
             metainfos.append(metainfo)
 
     def get_result_order(self, tr):
@@ -155,7 +239,13 @@ class TripuraBase(BaseGazette):
             elif txt and re.search('Gazette\s+No', txt):
                 order.append('gznum')
 
-            elif txt and re.search('Download', txt):
+            elif txt and re.search('Sector', txt):
+                order.append('sector')
+
+            elif txt and re.search('Policy', txt):
+                order.append('policy')
+
+            elif txt and (re.search('Download', txt) or re.search('Action', txt) or re.search('View', txt)):
                 order.append('download')
 
             else:
@@ -176,23 +266,63 @@ class TripuraBase(BaseGazette):
 
         return metainfos
 
-    def download_metainfos(self, dls, metainfos, curr_url, relpath):
+    def get_file_hash(self, doc_id, cookiejar):
+        ajax_url = self.baseurl + self.pdf_file_hash
+        postdata = [
+            ('generate_hash', '1'),
+            ('param', doc_id),
+        ]
+
+        referer = self.baseurl + self.search_endp
+
+        response = self.download_url(ajax_url, postdata=postdata, loadcookies=cookiejar, savecookies=cookiejar, referer=referer, headers=self.hash_headers)
+        if response is None or response.webpage is None:
+            self.logger.warning('Unable to get file hash for doc_id %s', doc_id)
+            return None
+
+        file_hash = response.webpage.decode('utf-8').strip()
+        return file_hash
+
+    def get_pdf_url(self, doc_id, file_hash, cookiejar):
+        embed_url = self.baseurl + self.html_pdf_embedding % (doc_id.split('~')[0], file_hash)
+        referer = self.baseurl + self.search_endp
+
+        response = self.download_url(embed_url, loadcookies=cookiejar,
+                                     savecookies=cookiejar, referer=referer)
+        if response is None or response.webpage is None:
+            self.logger.warning('Unable to get embedded pdf page for doc_id %s', doc_id)
+            return None
+
+        d = utils.parse_webpage(response.webpage, self.parser)
+        if d is None:
+            return None
+
+        obj_tag = d.find('object', {'type': 'application/pdf'})
+        if obj_tag and obj_tag.get('data'):
+            return urllib.parse.urljoin(self.baseurl, obj_tag['data'])
+
+        self.logger.warning('Unable to find pdf object tag for doc_id %s', doc_id)
+        return None
+
+    def download_metainfos(self, dls, metainfos, cookiejar, relpath):
         for metainfo in metainfos:
-            href   = metainfo.pop('href')
-            gzurl  = urllib.parse.urljoin(curr_url, href)
+            doc_id = metainfo.pop('doc_id')
 
-            #parsed   = urllib.parse.urlparse(href)
-            #bencoded = urllib.parse.parse_qs(parsed.query)['bencode'][0]
-            #bdecoded = base64.b64decode(base64.b64decode(bencoded))
-            #gztslno  = int(bdecoded)
+            file_hash = self.get_file_hash(doc_id, cookiejar)
+            if file_hash is None:
+                continue
 
-            gznum  = metainfo['gznum']
-            relurl  = os.path.join(relpath, f'{gznum}')
+            pdf_url = self.get_pdf_url(doc_id, file_hash, cookiejar)
+            if pdf_url is None:
+                continue
 
-            if self.save_gazette(relurl, gzurl, metainfo):
+            relurl = os.path.join(relpath, doc_id.replace('~', '_'))
+
+            if self.save_gazette(relurl, pdf_url, metainfo):
                 dls.append(relurl)
 
-
+    # Not being called by any function as the server is not using master token
+    # Marking as depricated for now, can be removed if the upcoming update also has no master token 
     def get_master_token(self, cookiejar, fromdate, todate, referer):
 
         jsurl = self.baseurl + "JavaScriptServlet"
@@ -215,6 +345,7 @@ class TripuraBase(BaseGazette):
 
         return master_token
 
+    # Not called by anyone, Marking as DEPRICATED can be removed in the upcoming update
     def update_token(self, master_token, cookiejar, fromdate, todate, referer):
 
         jsurl = self.baseurl + "JavaScriptServlet"
@@ -243,57 +374,60 @@ class TripuraBase(BaseGazette):
 
         return new_token
 
+    # The server returns multiple pdfs for a single day, required by the log to provide number of pdfs published for that day
+    def filter_by_date(self, metainfos, fromdate, todate):
+        filtered = []
+        for m in metainfos:
+            d = m.get_date()
+            if d and fromdate <= d <= todate:
+                filtered.append(m)
+        return filtered
+
     def download_oneday(self, relpath, dateobj):
         dls = []
         cookiejar = CookieJar()
         fromdate  = dateobj
         todate    = dateobj
 
-        response = self.download_url(self.baseurl, savecookies = cookiejar)
+        search_url = self.baseurl + self.search_endp
+        home_url   = self.baseurl + self.pdf_table_ref
+
+        response = self.download_url(search_url, savecookies=cookiejar, referer=home_url, headers=self.headers)
         if response is None or response.webpage is None:
-            self.logger.warning('Unable to download page at %s for %s to %s', \
-                                self.baseurl, fromdate, todate)
+            self.logger.warning('Unable to download search page for %s', dateobj)
             return dls
 
+        t.sleep(1)
 
-        results_table = None
-        search_url = None
+        captcha_value = self.solve_captcha(cookiejar)
+        if captcha_value is None:
+            return dls
 
-        while results_table is None:
-            curr_url = response.response_url
+        postdata = self.build_search_postdata(fromdate, todate, captcha_value)
 
-            import time
-            time.sleep(5)
+        response = self.download_url(search_url, postdata=postdata,
+                                     referer=home_url,
+                                     loadcookies=cookiejar, savecookies=cookiejar,
+                                     headers=self.search_headers)
+        if response is None or response.webpage is None:
+            self.logger.warning('Unable to get search results for %s', dateobj)
+            return dls
 
-            master_token = self.get_master_token(cookiejar, fromdate, todate, curr_url)
-            if master_token is None:
-                return dls
-
-            postdata = self.get_form_data(response.webpage, cookiejar, \
-                                          curr_url, fromdate, todate)
-            if postdata is None:
-                return dls
-
-            master_token = self.update_token(master_token, cookiejar, fromdate, todate, curr_url)
-
-            postdata.append(('NICeGazetteSecurity', master_token))
-
-
-            search_url = urllib.parse.urljoin(curr_url, self.search_endp)
-            search_url += f'?NICeGazetteSecurity={master_token}'
-
-            response = self.download_url(search_url, postdata = postdata, referer = curr_url, \
-                                         loadcookies = cookiejar, savecookies = cookiejar)
-            if response is None or response.webpage is None:
-                self.logger.warning('Unable to get search results at %s for %s to %s', \
-                                    search_url, fromdate, todate)
-                return dls
-
-            results_table = self.get_results_table(response.webpage)
+        results_table = self.get_results_table(response.webpage)
+        if results_table is None:
+            self.logger.warning('No results table found for %s', dateobj)
+            return dls
 
         metainfos = self.parse_results(results_table)
+        if not metainfos:
+            self.logger.info('No results found for %s', dateobj)
+            return dls
 
-        self.download_metainfos(dls, metainfos, curr_url, relpath)
+        filtered = self.filter_by_date(metainfos, fromdate, todate)
+        self.logger.info('Found %d total results, %d in date range for %s',
+                         len(metainfos), len(filtered), dateobj)
+
+        self.download_metainfos(dls, filtered, cookiejar, relpath)
 
         return dls
 

--- a/srcs/tripura.py
+++ b/srcs/tripura.py
@@ -198,11 +198,11 @@ class TripuraBase(BaseGazette):
                     issuedate = datetime.datetime.strptime(txt, '%d/%m/%Y').date()
                     metainfo.set_date(issuedate)
 
-                elif col == 'gztype':
-                    if txt == 'Extra-Ordinary':
-                        metainfo.set_gztype('Extraordinary')
-                    else:
-                        metainfo.set_gztype('Ordinary')
+                #elif col == 'gztype':
+                #    if txt == 'Extra-Ordinary':
+                #        metainfo.set_gztype('Extraordinary')
+                #    else:
+                #        metainfo.set_gztype('Ordinary')
 
                 elif col == 'download':
                     btn = td.find('button', {'name': 'viewDeptRouteDocument'})
@@ -212,6 +212,14 @@ class TripuraBase(BaseGazette):
                 elif col != '':
                     metainfo[col] = txt
             i += 1
+
+            # Tripura website does not provide gazette type column, we need to set by observing the API call
+            # Tripura server only returns extraordinary gazette, reject captcha when a gazette type is set in browser, even when the captcha is correct
+            if self.gztype:
+                if self.gztype == '2':
+                    metainfo.set_gztype('Extraordinary')
+                else:
+                    metainfo.set_gztype('Ordinary')
 
         if 'doc_id' in metainfo:
             metainfos.append(metainfo)

--- a/srcs/tripura.py
+++ b/srcs/tripura.py
@@ -245,6 +245,9 @@ class TripuraBase(BaseGazette):
             elif txt and re.search('Policy', txt):
                 order.append('policy')
 
+            elif txt and re.search('Organization', txt):
+                order.append('organization')
+
             elif txt and (re.search('Download', txt) or re.search('Action', txt) or re.search('View', txt)):
                 order.append('download')
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -316,6 +316,9 @@ PUBLISHER  = 'publisher'
 SUBDEPARTMENT = 'subdepartment'
 DOCTYPE    = 'doctype'
 CATEGORY   = 'category'
+POLICY     = 'policy'
+SECTOR     = 'sector'
+ORGANIZATION = 'organization'
 
 _illegal_xml_chars_RE = re.compile('[\x00-\x08\x0b\x0c\x0e-\x1F\uD800-\uDFFF\uFFFE\uFFFF]')
 
@@ -422,6 +425,15 @@ class MetaInfo(dict):
     def set_category(self, value):
         self.set_field(CATEGORY, value)
 
+    def set_policy(self, value):
+        self.set_field(POLICY, value)
+
+    def set_sector(self, value):
+        self.set_field(SECTOR, value)
+
+    def set_organization(self, value):
+        self.set_field(ORGANIZATION, value)
+
     def get_url(self):
         return self.get_field(URL)
 
@@ -499,6 +511,15 @@ class MetaInfo(dict):
     
     def get_category(self):
         return self.get_field(CATEGORY)
+
+    def get_policy(self):
+        return self.get_field(POLICY)
+
+    def get_sector(self):
+        return self.get_field(SECTOR)
+
+    def get_organization(self):
+        return self.get_field(ORGANIZATION)
 
 def stats_to_message(stats):
     rawstats  = stats[0]


### PR DESCRIPTION
  - Remove master token flow (server no longer requires it)
  - Add browser-matching headers for captcha and search requests
  - Build search POST data directly instead of parsing HTML form
  - Parse button-based download elements instead of anchor tags
  - Add AjaxServlet hash + embedded HTML scraping to download actual PDFs
  - Add date filtering counter for logging total number of pdfs per day
  - Remove client-side DataTables pagination handling (all rows in single response)