### PR TITLE
Fix arunachal egazzete

### DIFF
--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -93,7 +93,12 @@ class Arunachal(BaseGazette):
             download_url = metainfo.pop('download_url')
             download_url = urljoin(self.baseurl, download_url)
 
-            filename = download_url.split('/')[-1].rsplit('.', 1)[0].lower()
+            title = metainfo.get('title') or metainfo.get('subject')
+            if title:
+                filename = re.sub(r'[^\w\s-]', '', title).strip()
+                filename = re.sub(r'\s+', '-', filename).lower()
+            else:
+                filename = download_url.split('/')[-1].rsplit('.', 1)[0].lower()
 
         # Some gazettes in Arunachal does not have a year or date to create relurl, we store them as unknown
             year_str = str(year) if year is not None else 'unknown'

--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -94,8 +94,6 @@ class Arunachal(BaseGazette):
             download_url = metainfo.pop('download_url')
             download_url = urljoin(self.baseurl, download_url)
 
-            # Remove any brackets, special charecters
-            # Replace spaces with "-"
             title = metainfo.get('title') or metainfo.get('subject')
             if title:
                 filename = re.sub(r'[^\w\s-]', '', title).strip()
@@ -107,7 +105,6 @@ class Arunachal(BaseGazette):
             year_str = str(year) if year is not None else 'unknown'
             relpath = os.path.join(self.name, year_str)
             relurl = os.path.join(relpath, filename)
-        # Track relurl name for duplicates if found add _1, _2... to maintain uniqueness and avoid file overwrites
             if relurl in seen_relurls:
                 seen_relurls[relurl] += 1
                 relurl = f'{relurl}_{seen_relurls[relurl]}'

--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -94,6 +94,8 @@ class Arunachal(BaseGazette):
             download_url = metainfo.pop('download_url')
             download_url = urljoin(self.baseurl, download_url)
 
+            # Remove any brackets, special charecters
+            # Replace spaces with "-"
             title = metainfo.get('title') or metainfo.get('subject')
             if title:
                 filename = re.sub(r'[^\w\s-]', '', title).strip()
@@ -105,6 +107,7 @@ class Arunachal(BaseGazette):
             year_str = str(year) if year is not None else 'unknown'
             relpath = os.path.join(self.name, year_str)
             relurl = os.path.join(relpath, filename)
+        # Track relurl name for duplicates if found add _1, _2... to maintain uniqueness and avoid file overwrites
             if relurl in seen_relurls:
                 seen_relurls[relurl] += 1
                 relurl = f'{relurl}_{seen_relurls[relurl]}'

--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -80,6 +80,7 @@ class Arunachal(BaseGazette):
 
     def download_metainfos(self, metainfos, from_year, to_year):
         relurls = []
+        seen_relurls = {}
         for metainfo in metainfos:
             year = metainfo.get('year')
             if year is not None:
@@ -104,6 +105,11 @@ class Arunachal(BaseGazette):
             year_str = str(year) if year is not None else 'unknown'
             relpath = os.path.join(self.name, year_str)
             relurl = os.path.join(relpath, filename)
+            if relurl in seen_relurls:
+                seen_relurls[relurl] += 1
+                relurl = f'{relurl}_{seen_relurls[relurl]}'
+            else:
+                seen_relurls[relurl] = 0
             if self.save_gazette(relurl, download_url, metainfo):
                 relurls.append(relurl)
 

--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -93,12 +93,7 @@ class Arunachal(BaseGazette):
             download_url = metainfo.pop('download_url')
             download_url = urljoin(self.baseurl, download_url)
 
-            title = metainfo.get('title') or metainfo.get('subject')
-            if title:
-                filename = re.sub(r'[^\w\s-]', '', title).strip()
-                filename = re.sub(r'\s+', '-', filename).lower()
-            else:
-                filename = download_url.split('/')[-1].rsplit('.', 1)[0].lower()
+            filename = download_url.split('/')[-1].rsplit('.', 1)[0].lower()
 
         # Some gazettes in Arunachal does not have a year or date to create relurl, we store them as unknown
             year_str = str(year) if year is not None else 'unknown'

--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -80,7 +80,6 @@ class Arunachal(BaseGazette):
 
     def download_metainfos(self, metainfos, from_year, to_year):
         relurls = []
-        seen_relurls = {}
         for metainfo in metainfos:
             year = metainfo.get('year')
             if year is not None:
@@ -105,11 +104,6 @@ class Arunachal(BaseGazette):
             year_str = str(year) if year is not None else 'unknown'
             relpath = os.path.join(self.name, year_str)
             relurl = os.path.join(relpath, filename)
-            if relurl in seen_relurls:
-                seen_relurls[relurl] += 1
-                relurl = f'{relurl}_{seen_relurls[relurl]}'
-            else:
-                seen_relurls[relurl] = 0
             if self.save_gazette(relurl, download_url, metainfo):
                 relurls.append(relurl)
 

--- a/srcs/arunachal.py
+++ b/srcs/arunachal.py
@@ -81,14 +81,15 @@ class Arunachal(BaseGazette):
     def download_metainfos(self, metainfos, from_year, to_year):
         relurls = []
         for metainfo in metainfos:
-            year = metainfo.get('year')
-            if year is not None:
-                try:
-                    year_int = int(year)
-                    if year_int < from_year or year_int > to_year:
-                        continue
-                except (ValueError, TypeError):
-                    pass
+            #Do not check for year or date, download all the pdfs from the table since arunachal has less number of pdfs
+            #year = metainfo.get('year')
+            #if year is not None:
+            #    try:
+            #        year_int = int(year)
+            #        if year_int < from_year or year_int > to_year:
+            #            continue
+            #    except (ValueError, TypeError):
+            #        pass
 
             download_url = metainfo.pop('download_url')
             download_url = urljoin(self.baseurl, download_url)
@@ -96,9 +97,13 @@ class Arunachal(BaseGazette):
             filename = download_url.split('/')[-1].rsplit('.', 1)[0].lower()
 
         # Some gazettes in Arunachal does not have a year or date to create relurl, we store them as unknown
-            year_str = str(year) if year is not None else 'unknown'
-            relpath = os.path.join(self.name, year_str)
-            relurl = os.path.join(relpath, filename)
+        #    year_str = str(year) if year is not None else 'unknown'
+        #    relpath = os.path.join(self.name, year_str)
+        #    relurl = os.path.join(relpath, filename)
+
+        # PDF section/tags have different year then the actual pdf date, store them with their hash
+
+            relurl = os.path.join(self.name, filename)
             if self.save_gazette(relurl, download_url, metainfo):
                 relurls.append(relurl)
 


### PR DESCRIPTION
- Comment out date/year range validations to download all available PDFs
- Bypass problematic year-based directory nesting due to mismatched section/tag years
- Simplify file storage by saving PDFs directly under the state folder using the filename slug